### PR TITLE
인증메일 발송 및 인증 API 경로 변경 예정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/controller/MailController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/controller/MailController.kt
@@ -1,0 +1,47 @@
+package com.wafflestudio.toyproject.memoWithTags.mail.controller
+
+import com.wafflestudio.toyproject.memoWithTags.exception.annotation.ApiErrorCodeExamples
+import com.wafflestudio.toyproject.memoWithTags.mail.docs.SendEmailExceptionDocs
+import com.wafflestudio.toyproject.memoWithTags.mail.docs.VerifyEmailExceptionDocs
+import com.wafflestudio.toyproject.memoWithTags.mail.dto.MailRequest.SendMailRequest
+import com.wafflestudio.toyproject.memoWithTags.mail.dto.MailRequest.VerifyMailRequest
+import com.wafflestudio.toyproject.memoWithTags.mail.service.MailVerifService
+import com.wafflestudio.toyproject.memoWithTags.mail.service.SendMailType
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "mail api", description = "메일 관련 api")
+@RestController
+@RequestMapping("/api/v1")
+class MailController(
+    private val mailVerifService: MailVerifService,
+) {
+    @ApiErrorCodeExamples(SendEmailExceptionDocs::class)
+    @Operation(summary = "메일 인증 요청")
+    @PostMapping("/mail")
+    fun sendMail(
+        @RequestBody request: SendMailRequest,
+        @RequestParam type: SendMailType
+    ): ResponseEntity<Unit> {
+        mailVerifService.sendCodeToMail(request.email, type)
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+    }
+
+    @ApiErrorCodeExamples(VerifyEmailExceptionDocs::class)
+    @Operation(summary = "메일 인증 확인")
+    @PostMapping("/mail/verify")
+    fun verifyMail(
+        @RequestBody request: VerifyMailRequest,
+        @RequestParam type: SendMailType
+    ): ResponseEntity<Unit> {
+        mailVerifService.verifyMail(request.email, request.verificationCode, type)
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/docs/SendEmailExceptionDocs.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/docs/SendEmailExceptionDocs.kt
@@ -1,0 +1,12 @@
+package com.wafflestudio.toyproject.memoWithTags.mail.docs
+
+import com.wafflestudio.toyproject.memoWithTags.exception.annotation.ExceptionDoc
+import com.wafflestudio.toyproject.memoWithTags.exception.annotation.ExplainError
+import com.wafflestudio.toyproject.memoWithTags.exception.code.ErrorCode
+
+@ExceptionDoc
+object SendEmailExceptionDocs {
+
+    @field:ExplainError("이메일 전송에 실패했습니다.")
+    val USER_UNABLE_TO_SEND_EMAIL = ErrorCode.USER_UNABLE_TO_SEND_EMAIL
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/docs/VerifyEmailExceptionDocs.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/docs/VerifyEmailExceptionDocs.kt
@@ -1,0 +1,12 @@
+package com.wafflestudio.toyproject.memoWithTags.mail.docs
+
+import com.wafflestudio.toyproject.memoWithTags.exception.annotation.ExceptionDoc
+import com.wafflestudio.toyproject.memoWithTags.exception.annotation.ExplainError
+import com.wafflestudio.toyproject.memoWithTags.exception.code.ErrorCode
+
+@ExceptionDoc
+object VerifyEmailExceptionDocs {
+
+    @field:ExplainError("이메일이 인증되지 않았습니다")
+    val USER_MAIL_VERIFICATION_FAILED = ErrorCode.USER_MAIL_VERIFICATION_FAILED
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/dto/MailRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/dto/MailRequest.kt
@@ -1,0 +1,12 @@
+package com.wafflestudio.toyproject.memoWithTags.mail.dto
+
+sealed class MailRequest {
+    data class SendMailRequest(
+        val email: String
+    ) : MailRequest()
+
+    data class VerifyMailRequest(
+        val email: String,
+        val verificationCode: String
+    ) : MailRequest()
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/service/MailVerifService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/service/MailVerifService.kt
@@ -1,0 +1,72 @@
+package com.wafflestudio.toyproject.memoWithTags.mail.service
+
+import com.wafflestudio.toyproject.memoWithTags.exception.exceptions.EmailSendingException
+import com.wafflestudio.toyproject.memoWithTags.exception.exceptions.MailVerificationException
+import com.wafflestudio.toyproject.memoWithTags.mail.EmailVerification
+import com.wafflestudio.toyproject.memoWithTags.mail.persistence.EmailVerificationEntity
+import com.wafflestudio.toyproject.memoWithTags.mail.persistence.EmailVerificationRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class MailVerifService(
+    private val emailVerificationRepository: EmailVerificationRepository,
+    private val mailService: MailService
+) {
+    /**
+     * 회원가입 또는 비밀번호 재설정 등 목적에 따른 인증용 메일을 발송하는 함수
+     */
+    @Transactional
+    fun sendCodeToMail(
+        email: String,
+        purpose: SendMailType
+    ) {
+        // 이미 인증 메일을 보낸 주소로 또 시도하는 경우에는 해당 이메일로 발송된 인증번호 데이터를 삭제한다.
+        emailVerificationRepository.deleteAllById(email)
+
+        val purposeAndEmail = "${purpose.name},$email"
+        val hangulPurpose = when (purpose) {
+            SendMailType.Register -> "회원가입"
+            SendMailType.ResetPassword -> "비밀번호 재설정"
+        }
+        val verification: EmailVerification = mailService.createVerificationCode(purposeAndEmail)
+        val verifCode = verification.code
+        val title = "[Memo with tags] 인증번호 [$verifCode] 를 입력해주세요"
+        val content: String = "<html>" +
+                "<body>" +
+                "<h1>인증번호 안내</h1>" +
+                "<p>안녕하세요, Memo with tags 팀입니다.</p>" +
+                "<b>[${hangulPurpose}]을 위해, 아래의 인증번호 6자리를 진행 중인 화면에 입력하여 5분 내에 인증을 완료해주세요.</b>" +
+                "<h2>인증번호<br>$verifCode</h2>" +
+                "<p>인증번호는 이메일 발송 시점으로부터 3분 동안 유효합니다.</p>" +
+                "<footer style='color: grey; font-size: small;'>" +
+                "<p>본 메일은 자동응답 메일이므로 본 메일에 회신하지 마시기 바랍니다.</p>" +
+                "</footer>" +
+                "</body>" +
+                "</html>"
+        try {
+            mailService.sendMail(email, title, content)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            throw EmailSendingException()
+        }
+    }
+
+    /**
+     * 특정 목적에 의해 메일로 보내진 인증 번호와 유저가 입력한 인증 번호가 일치하는지 검증하는 함수
+     */
+    @Transactional
+    fun verifyMail(
+        email: String,
+        code: String,
+        purpose: SendMailType
+    ): Boolean {
+        val purposeAndEmail = "${purpose.name},$email"
+        val verification = emailVerificationRepository.findByIdOrNull(purposeAndEmail) ?: throw MailVerificationException()
+        if (verification.code != code) throw MailVerificationException()
+        // 인증 성공 시, verification의 Verified 필드가 true로 바뀌어 회원가입의 검증 절차를 통과한다.
+        emailVerificationRepository.save(EmailVerificationEntity(email, code, true))
+        return true
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/service/SendMailType.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/service/SendMailType.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.toyproject.memoWithTags.mail.service
+
+enum class SendMailType {
+    Register, ResetPassword
+}


### PR DESCRIPTION
## 작업 내용

- [ ] 주요 변경 사항 요약: 메일 인증 관련 API를 MailController로 이동, 동시에 로직 조금 수정하면서 API 경로 수정, 일단 기존 API 열어둠
- [ ] 관련 이슈 번호 (e.g., #123)

## 테스트 결과

- [ ] 로컬에서 테스트 완료
- [ ] CI 통과 여부 확인

## 참고 사항

- 추가적인 설명이 필요하다면 작성해주세요.